### PR TITLE
Fix blocking call warning in camera component

### DIFF
--- a/custom_components/moderntides/camera.py
+++ b/custom_components/moderntides/camera.py
@@ -1,4 +1,6 @@
 """Camera platform for Modern Tides integration."""
+import aiofiles
+import aiofiles.os
 import logging
 import os
 import time
@@ -169,14 +171,14 @@ class ModernTidesCamera(Camera):
         try:
             if self._image_filename is not None:
                 # Read the SVG file directly (filename already includes the correct mode suffix)
-                if os.path.exists(self._image_filename):
+                if await aiofiles.os.path.exists(self._image_filename):
                     # Check if SVG file has been updated
-                    file_mtime = os.path.getmtime(self._image_filename)
+                    file_mtime = await aiofiles.os.path.getmtime(self._image_filename)
                     
                     if self._last_updated is None or file_mtime > self._last_updated:
-                        # Read SVG content and convert to bytes
-                        with open(self._image_filename, "r", encoding='utf-8') as svg_file:
-                            svg_content = svg_file.read()
+                        # Read SVG content and convert to bytes (non-blocking)
+                        async with aiofiles.open(self._image_filename, "r", encoding='utf-8') as svg_file:
+                            svg_content = await svg_file.read()
                         
                         # For SVG content, we need to return it as bytes
                         # Home Assistant can handle SVG content type

--- a/custom_components/moderntides/manifest.json
+++ b/custom_components/moderntides/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/ALArvi019/moderntides/issues",
   "quality_scale": "silver",
   "requirements": ["requests>=2.25.0", "aiofiles>=23.0.0"],
-  "version": "1.1.3"
+  "version": "1.1.4"
 }

--- a/custom_components/moderntides/manifest.json
+++ b/custom_components/moderntides/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ALArvi019/moderntides/issues",
   "quality_scale": "silver",
-  "requirements": ["requests>=2.25.0"],
+  "requirements": ["requests>=2.25.0", "aiofiles>=23.0.0"],
   "version": "1.1.3"
 }


### PR DESCRIPTION
## Description

This PR fixes the blocking call warning reported in issue #7 where Home Assistant was detecting synchronous I/O operations in the event loop.

## Changes Made

### 🔧 Code Changes
- **camera.py**: Replaced synchronous file operations with asynchronous equivalents:
  - `open()` → `aiofiles.open()`
  - `os.path.exists()` → `aiofiles.os.path.exists()`
  - `os.path.getmtime()` → `aiofiles.os.path.getmtime()`

### 📦 Dependencies
- **manifest.json**: Added `aiofiles>=23.0.0` dependency

## Problem Solved

The original warning was:
```
WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to open with args ('/config/www/moderntides_barbate_plot.svg', 'r') inside the event loop by custom integration 'moderntides' at custom_components/moderntides/camera.py, line 178
```

This occurred because:
1. `async_update()` method was using synchronous `open()` calls
2. File system operations like `os.path.exists()` and `os.path.getmtime()` were blocking the event loop
3. Home Assistant's asyncio loop detected these as performance issues

## Solution

By using `aiofiles`, all file operations are now truly asynchronous and won't block the Home Assistant event loop, improving overall system performance and eliminating the warning.

## Testing

The changes maintain the same functionality while making the operations non-blocking:
- SVG files are still read correctly
- File modification time checking still works
- Error handling remains the same
- Dark/light mode functionality preserved

## Closes

Fixes #7